### PR TITLE
chore: Redeploy on nitrosvmtestnet

### DIFF
--- a/rust/NOTES_PETAR.md
+++ b/rust/NOTES_PETAR.md
@@ -1,7 +1,7 @@
-Command for running the rollup (inside of `svm-rollup/crates/rollup`):
+1. Command for running the rollup:
 
 ```bash
-make run-mock
+just rollup run-mock
 ```
 
 With changing the https config to:
@@ -11,31 +11,41 @@ With changing the https config to:
 bind_port = 8999
 ```
 
-Command for running the solana test validator:
+2. Command for running the solana test validator:
 
 ```bash
 solana-test-validator
 ```
 
-Command for deploying core to nitrosvmlocalnet:
+3. Command for deploying core to nitrosvmlocalnet:
 
 ```bash
-cargo run -- -k ~/.config/solana/id.json --url http://localhost:8999/rpc \
+cargo run -- -k ~/.config/solana/id.json -u http://localhost:8999/rpc \
         core deploy --environment nitro-local \
         --environments-dir ../environments/ --chain nitrosvmlocalnet \
         --built-so-dir ../target/deploy/ --local-domain 13440
 ```
 
-Command for deploying core to solanalocalnet:
+4. Command for deploying core to solanalocalnet:
 
 ```bash
-cargo run -- -k ~/.config/solana/id.json --url http://localhost:8899 \
+cargo run -- -k ~/.config/solana/id.json -u http://localhost:8899 \
         core deploy --environment nitro-local \
         --environments-dir ../environments/ --chain solanalocalnet \
         --built-so-dir ../target/deploy/ --local-domain 13377
 ```
 
-Command for deploying the warp route:
+5. Command for ISM configuration:
+
+```bash
+cargo run -- -k ~/.config/solana/id.json -u http://localhost:8999/rpc \
+        multisig-ism-message-id configure \
+        --program-id 7hWAvb6Y8vMpniQpBWpx7jN5BSZXLU7DbqRHh2heCLZs \
+        --chain-config-file ../environments/nitro-local/chain-config.json \
+        --multisig-config-file ../environments/nitro-local/multisig-ism-message-id/nitrosvmlocalnet/hyperlane/multisig-config.json
+```
+
+6. Command for deploying the warp route:
 
 ```bash
 cargo run -- -k ~/.config/solana/id.json \
@@ -48,7 +58,26 @@ cargo run -- -k ~/.config/solana/id.json \
         --ata-payer-funding-amount 10000000
 ```
 
-Command for validator:
+7. Command for IGP configuration:
+
+```bash
+cargo run -- -k ~/.config/solana/id.json -u http://localhost:8899 \
+        igp configure \
+        --program-id CpP9nXDsQsifneJgwZ3pX8iwFUFGk5Bu3Ph5gdyeN7zw \
+        --gas-oracle-config-file ../environments/nitro-local/gas-oracle-configs.json \
+        --chain-config-file ../environments/nitro-local/chain-config.json \
+        --chain solanadevnet
+```
+
+8. Command for querying the Token collateral account of a warp route deployment:
+
+```bash
+cargo run -- -k ~/.config/solana/id.json -u http://localhost:8899 \
+        token query \
+        --program-id FBxoyKyCe4rYkJQMVUFYqV1U7WdeC2WVV8m1RuDHZrrY native
+```
+
+9. Command for validator:
 
 ```bash
 cargo run -p validator --release -- \
@@ -60,27 +89,7 @@ cargo run -p validator --release -- \
         --checkpointSyncer.path "/tmp/hyperlane-validator-signatures-svm"
 ```
 
-Command for relayer:
-
-```bash
-cargo run -p relayer --release -- \
-        --config-path ./config/nitro_localnet_config.json \
-        --relayChains nitrosvmlocalnet,solanalocalnet \
-        --allowLocalCheckpointSyncers true \
-        --defaultSigner.key "0xb48bc90c3fb62d1e72ee5481ce5659e6c1261f7db8e4ba26c657dc8c9fe937e0"
-```
-
-Command for ISM configuration:
-
-```bash
-cargo run -- -k ~/.config/solana/id.json --url http://localhost:8999/rpc \
-        multisig-ism-message-id configure \
-        --program-id 7hWAvb6Y8vMpniQpBWpx7jN5BSZXLU7DbqRHh2heCLZs \
-        --chain-config-file ../environments/nitro-local/chain-config.json \
-        --multisig-config-file ../environments/nitro-local/multisig-ism-message-id/nitrosvmlocalnet/hyperlane/multisig-config.json
-```
-
-Command for validator announce:
+10. Command for validator announce:
 
 ```bash
 cargo run -- -k ~/.config/solana/id.json -u http://localhost:8899/ \
@@ -91,30 +100,21 @@ cargo run -- -k ~/.config/solana/id.json -u http://localhost:8899/ \
         --signature 0x5e9a7ae15ac3657d8c9da45cf7b9690bf59d7454572428134a356a426653f95d28e558943cd04c13d79796c030e64d5a716f2ce388214a50c4ed012e5747c6fb1c
 ```
 
-Command for token transfer:
+11. Command for relayer:
+
+```bash
+cargo run -p relayer --release -- \
+        --config-path ./config/nitro_localnet_config.json \
+        --relayChains nitrosvmlocalnet,solanalocalnet \
+        --allowLocalCheckpointSyncers true \
+        --defaultSigner.key "0xb48bc90c3fb62d1e72ee5481ce5659e6c1261f7db8e4ba26c657dc8c9fe937e0"
+```
+
+12. Command for token transfer:
 
 ```bash
 cargo run -- -k ~/.config/solana/id.json -u http://localhost:8899 \
         token transfer-remote ~/.config/solana/id.json \
         100000 13440 2MCVmcuUcREwQKDS3HazuYctkkbZV3XRMspM5eLWRZUV \
         native --program-id 7fYBqSMrPi29LLjr98BhPTHwfqtKjYVk7h14C8enjB9m
-```
-
-Command for IGP configuration:
-
-```bash
-cargo run -- -k ~/.config/solana/id.json -u https://api.devnet.solana.com \
-        igp configure \
-        --program-id CpP9nXDsQsifneJgwZ3pX8iwFUFGk5Bu3Ph5gdyeN7zw \
-        --gas-oracle-config-file ../environments/nitro-test/gas-oracle-configs.json \
-        --chain-config-file ../environments/nitro-test/chain-config.json \
-        --chain solanadevnet
-```
-
-Command for querying the Token collateral account of a warp route deployment:
-
-```bash
-cargo run -- -k ~/.config/solana/id.json -u https://api.devnet.solana.com \
-        token query \
-        --program-id FBxoyKyCe4rYkJQMVUFYqV1U7WdeC2WVV8m1RuDHZrrY native
 ```

--- a/rust/main/config/nitro_testnet_config.json
+++ b/rust/main/config/nitro_testnet_config.json
@@ -62,11 +62,11 @@
         "from": 1,
         "mode": "sequence"
       },
-      "interchainGasPaymaster": "5g5QYReSSZujSeEC4UbuPiKWYSq6CperHiZ8DLKm2yCf",
-      "interchainSecurityModule": "3d66PUPWBtrkKzT42xZSpTDoWid6vMtBMHMnZvQxJaa4",
+      "interchainGasPaymaster": "9B6nkwp4Tup7QbNLwku5ZudtFQx2NiSK2SgJDxs6Jt7A",
+      "interchainSecurityModule": "AKfwhWgnf8b1ET8JTKFFxkUJxfswMDkgR3rBYpcd2hU7",
       "isTestnet": true,
-      "mailbox": "7hFbauzs6PpVtsLFmN34rvwMQBh1Aevdwi9Pt42ALSL",
-      "merkleTreeHook": "7hFbauzs6PpVtsLFmN34rvwMQBh1Aevdwi9Pt42ALSL",
+      "mailbox": "4UpZnDVReudJqRowPKo3TDKmRP7jyPVPMt2t9D88dEgC",
+      "merkleTreeHook": "4UpZnDVReudJqRowPKo3TDKmRP7jyPVPMt2t9D88dEgC",
       "name": "nitrosvmtestnet",
       "nativeToken": {
         "decimals": 9,
@@ -79,7 +79,7 @@
           "http": "http://rpc.termina.technology"
         }
       ],
-      "validatorAnnounce": "8NaPEmpEbY8Nj3a5NYniUXEojnGwhrkispexhcHZX77Z"
+      "validatorAnnounce": "2xQnQsu2sQciV7HkTj6D2V3Kt8aHZPRvDTkS2dZowSzs"
     }
   }
 }

--- a/rust/sealevel/environments/nitro-test/nitrosvmtestnet/core/program-ids.json
+++ b/rust/sealevel/environments/nitro-test/nitrosvmtestnet/core/program-ids.json
@@ -1,8 +1,8 @@
 {
-  "mailbox": "7hFbauzs6PpVtsLFmN34rvwMQBh1Aevdwi9Pt42ALSL",
-  "validator_announce": "8NaPEmpEbY8Nj3a5NYniUXEojnGwhrkispexhcHZX77Z",
-  "multisig_ism_message_id": "3d66PUPWBtrkKzT42xZSpTDoWid6vMtBMHMnZvQxJaa4",
-  "igp_program_id": "8o2iVyMiXgRQQMn4KB5m9SnXoEXRoi6Eyi9hRqiKTHy4",
-  "overhead_igp_account": "4Tra7AjbMEmiMH1mqB6mmxapxS6yhSZNALc8hGZreoRf",
-  "igp_account": "5g5QYReSSZujSeEC4UbuPiKWYSq6CperHiZ8DLKm2yCf"
+  "mailbox": "4UpZnDVReudJqRowPKo3TDKmRP7jyPVPMt2t9D88dEgC",
+  "validator_announce": "2xQnQsu2sQciV7HkTj6D2V3Kt8aHZPRvDTkS2dZowSzs",
+  "multisig_ism_message_id": "AKfwhWgnf8b1ET8JTKFFxkUJxfswMDkgR3rBYpcd2hU7",
+  "igp_program_id": "3i6aM5iS7aj63C7vJ3EqaSDFcA6xV79omeK6oAS1nGm1",
+  "overhead_igp_account": "2hq8o5fwAPyrn9R5M6KbkkJ1qsQjRit8XywoQL2Kdf3W",
+  "igp_account": "9B6nkwp4Tup7QbNLwku5ZudtFQx2NiSK2SgJDxs6Jt7A"
 }

--- a/rust/sealevel/environments/nitro-test/warp-routes/sol-nitrotestnet-solanadevnet/program-ids.json
+++ b/rust/sealevel/environments/nitro-test/warp-routes/sol-nitrotestnet-solanadevnet/program-ids.json
@@ -1,10 +1,10 @@
 {
-  "nitrosvmtestnet": {
-    "hex": "0xb749d06e21a9385d5c46ade4d7bb07348915c792849f84cf1546fb7bf09a53a5",
-    "base58": "DLUte4EM98j8Dk56xFpX15aJoDs3fxBBrX2FpZMxRDSU"
-  },
   "solanadevnet": {
     "hex": "0xd2d2878a647dca5527c481c872a8763567c31dd71dc0fd2c9ec0d75738b15d9d",
     "base58": "FBxoyKyCe4rYkJQMVUFYqV1U7WdeC2WVV8m1RuDHZrrY"
+  },
+  "nitrosvmtestnet": {
+    "hex": "0x3d46b1de4d7bb72eb17b0d618f9fac0188b5a72e23928d0c4cb36f049a6e69c0",
+    "base58": "58CPm3ERePAYxX24kt4cATdNLVtWFrjZAHYuQBea4zzj"
   }
 }

--- a/rust/sealevel/environments/nitro-test/warp-routes/sol-nitrotestnet-solanadevnet/token-config.json
+++ b/rust/sealevel/environments/nitro-test/warp-routes/sol-nitrotestnet-solanadevnet/token-config.json
@@ -2,7 +2,7 @@
   "nitrosvmtestnet": {
     "type": "native",
     "decimals": 9,
-    "interchainGasPaymaster": "5g5QYReSSZujSeEC4UbuPiKWYSq6CperHiZ8DLKm2yCf"
+    "interchainGasPaymaster": "9B6nkwp4Tup7QbNLwku5ZudtFQx2NiSK2SgJDxs6Jt7A"
   },
   "solanadevnet": {
     "type": "native",


### PR DESCRIPTION
### Description

Update Nitro testnet contract addresses in configuration files. This includes changes to the interchain gas paymaster, interchain security module, mailbox, merkle tree hook, and validator announce addresses in both the main config and program-ids files. Also updates the domain identifier for nitrosvmtestnet in the warp routes configuration.

### Drive-by changes

None

### Related issues

None

### Backward compatibility

No - these changes update contract addresses which would prevent older commits from working with the updated infrastructure.